### PR TITLE
#76 Silinen WareHouse kayıtlarının gösterilmesi için endpoint geliştirmesi

### DIFF
--- a/src/main/java/com/study/stockmanagementstudycase/controller/WareHouseController.java
+++ b/src/main/java/com/study/stockmanagementstudycase/controller/WareHouseController.java
@@ -84,6 +84,19 @@ public class WareHouseController {
         return ResponseEntity.ok(wareHouseResponse);
     }
 
+    @GetMapping("/deleted")
+    public ResponseEntity<CustomPagingResponse<WareHouseResponse>> getDeletedWareHouses(
+            @RequestBody @Valid final WareHousePagingRequest wareHousePagingRequest
+    ) {
+        final CustomPage<WareHouse> deletedWareHouses = wareHouseService
+                .getDeletedWareHouses(wareHousePagingRequest);
+
+        final CustomPagingResponse<WareHouseResponse> response = WareHouseDTOMapper
+                .toPagingResponse(deletedWareHouses);
+
+        return ResponseEntity.ok(response);
+    }
+
     /**
      * Update a warehouse by its ID.
      *

--- a/src/main/java/com/study/stockmanagementstudycase/model/mappers/wareHouse/WareHouseMapper.java
+++ b/src/main/java/com/study/stockmanagementstudycase/model/mappers/wareHouse/WareHouseMapper.java
@@ -1,13 +1,12 @@
 package com.study.stockmanagementstudycase.model.mappers.wareHouse;
 
-import com.study.stockmanagementstudycase.common.model.dto.CustomPage;
 import com.study.stockmanagementstudycase.model.WareHouse;
 import com.study.stockmanagementstudycase.model.dto.request.wareHouse.WareHouseCreateRequest;
 import com.study.stockmanagementstudycase.model.dto.request.wareHouse.WareHouseUpdateRequest;
 import com.study.stockmanagementstudycase.model.entities.WareHouseEntity;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
-import java.util.Objects;
 
 public class WareHouseMapper {
 
@@ -43,6 +42,14 @@ public class WareHouseMapper {
             final List<WareHouseEntity> wareHouseEntityList
     ) {
         return wareHouseEntityList.stream()
+                .map(WareHouseMapper::toDomainModel)
+                .toList();
+    }
+
+    public static List<WareHouse> toDomainModel(
+            final Page<WareHouseEntity> wareHouseEntityPage
+    ) {
+        return wareHouseEntityPage.stream()
                 .map(WareHouseMapper::toDomainModel)
                 .toList();
     }

--- a/src/main/java/com/study/stockmanagementstudycase/repository/WareHouseRepository.java
+++ b/src/main/java/com/study/stockmanagementstudycase/repository/WareHouseRepository.java
@@ -1,22 +1,20 @@
 package com.study.stockmanagementstudycase.repository;
 
 import com.study.stockmanagementstudycase.model.entities.WareHouseEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WareHouseRepository extends JpaRepository<WareHouseEntity, String> {
 
-    /**
-     * Checks WareHouseEntity in database by name or address field.
-     * If entity exists returns true
-     *
-     * @param name
-     * @param address
-     * @return
-     */
     boolean existsWareHouseEntitiesByNameAndAddress(
             String name,
             String address
+    );
+
+    Page<WareHouseEntity> findWareHouseEntitiesByStatusIsFalse(
+            final Pageable pageable
     );
 }

--- a/src/main/java/com/study/stockmanagementstudycase/service/wareHouse/WareHouseService.java
+++ b/src/main/java/com/study/stockmanagementstudycase/service/wareHouse/WareHouseService.java
@@ -13,4 +13,8 @@ public interface WareHouseService {
     WareHouse getWareHouseById(
             final String wareHouseId
     );
+
+    CustomPage<WareHouse> getDeletedWareHouses(
+            final CustomPagingRequest customPagingRequest
+    );
 }

--- a/src/main/java/com/study/stockmanagementstudycase/service/wareHouse/impl/WareHouseServiceImpl.java
+++ b/src/main/java/com/study/stockmanagementstudycase/service/wareHouse/impl/WareHouseServiceImpl.java
@@ -54,4 +54,25 @@ public class WareHouseServiceImpl implements WareHouseService {
                 .toDomainModel(wareHouseEntityFromDb);
     }
 
+    @Override
+    public CustomPage<WareHouse> getDeletedWareHouses(
+            final CustomPagingRequest customPagingRequest
+    ) {
+        final Page<WareHouseEntity> deletedWareHouseEntityPage = wareHouseRepository
+                .findWareHouseEntitiesByStatusIsFalse(
+                        customPagingRequest.toPageable()
+                );
+
+        if (Boolean.FALSE.equals(deletedWareHouseEntityPage.hasContent())) {
+            throw new WareHouseNotFoundException("Silinmiş bir depo kaydınız yok!");
+        }
+
+        final List<WareHouse> wareHouseDomainModels = WareHouseMapper
+                .toDomainModel(deletedWareHouseEntityPage);
+
+        return CustomPage.of(
+                wareHouseDomainModels,
+                deletedWareHouseEntityPage
+        );
+    }
 }

--- a/src/main/resources/db/changelog/changes/2-warehouse-dml.xml
+++ b/src/main/resources/db/changelog/changes/2-warehouse-dml.xml
@@ -20,7 +20,7 @@
             <column name="ID" value="b4a785b5-3903-4701-83c7-a14e240875ef"/>
             <column name="NAME" value="Bagcilar Deposu"/>
             <column name="ADDRESS" value="Istanbul/Bagcilar"/>
-            <column name="STATUS" value="1"/>
+            <column name="STATUS" value="0"/>
             <column name="CREATED_AT" value="2023-11-22 09:00:00"/>
         </insert>
     </changeSet>

--- a/src/test/java/com/study/stockmanagementstudycase/StockEntityManagementStudyCaseApplicationTests.java
+++ b/src/test/java/com/study/stockmanagementstudycase/StockEntityManagementStudyCaseApplicationTests.java
@@ -6,8 +6,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class StockEntityManagementStudyCaseApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
-
 }

--- a/src/test/java/com/study/stockmanagementstudycase/builder/dto/CustomPagingBuilder.java
+++ b/src/test/java/com/study/stockmanagementstudycase/builder/dto/CustomPagingBuilder.java
@@ -1,0 +1,35 @@
+package com.study.stockmanagementstudycase.builder.dto;
+
+import com.study.stockmanagementstudycase.builder.BaseBuilder;
+import com.study.stockmanagementstudycase.common.model.dto.CustomPaging;
+
+public class CustomPagingBuilder extends BaseBuilder<CustomPaging> {
+    public CustomPagingBuilder() {
+        super(CustomPaging.class);
+    }
+
+    public CustomPagingBuilder withValidFields() {
+        return this
+                .withPageNumber(1)
+                .withPageSize(5);
+    }
+
+    public CustomPagingBuilder withPageNumber(
+            final Integer pageNumber
+    ) {
+        data.setPageNumber(pageNumber);
+        return this;
+    }
+
+    public CustomPagingBuilder withPageSize(
+            final Integer pageSize
+    ) {
+        data.setPageSize(pageSize);
+        return this;
+    }
+
+    @Override
+    public CustomPaging build() {
+        return super.build();
+    }
+}

--- a/src/test/java/com/study/stockmanagementstudycase/builder/dto/stock/StockCreateRequestBuilder.java
+++ b/src/test/java/com/study/stockmanagementstudycase/builder/dto/stock/StockCreateRequestBuilder.java
@@ -1,4 +1,4 @@
-package com.study.stockmanagementstudycase.builder.dto;
+package com.study.stockmanagementstudycase.builder.dto.stock;
 
 import com.github.javafaker.Faker;
 import com.study.stockmanagementstudycase.builder.BaseBuilder;

--- a/src/test/java/com/study/stockmanagementstudycase/builder/dto/stock/StockUpdateRequestBuilder.java
+++ b/src/test/java/com/study/stockmanagementstudycase/builder/dto/stock/StockUpdateRequestBuilder.java
@@ -1,4 +1,4 @@
-package com.study.stockmanagementstudycase.builder.dto;
+package com.study.stockmanagementstudycase.builder.dto.stock;
 
 import com.github.javafaker.Faker;
 import com.study.stockmanagementstudycase.builder.BaseBuilder;

--- a/src/test/java/com/study/stockmanagementstudycase/builder/dto/wareHouse/WareHouseCreateRequestBuilder.java
+++ b/src/test/java/com/study/stockmanagementstudycase/builder/dto/wareHouse/WareHouseCreateRequestBuilder.java
@@ -1,4 +1,4 @@
-package com.study.stockmanagementstudycase.builder.dto;
+package com.study.stockmanagementstudycase.builder.dto.wareHouse;
 
 import com.github.javafaker.Faker;
 import com.study.stockmanagementstudycase.builder.BaseBuilder;

--- a/src/test/java/com/study/stockmanagementstudycase/builder/dto/wareHouse/WareHousePagingRequestBuilder.java
+++ b/src/test/java/com/study/stockmanagementstudycase/builder/dto/wareHouse/WareHousePagingRequestBuilder.java
@@ -1,0 +1,29 @@
+package com.study.stockmanagementstudycase.builder.dto.wareHouse;
+
+import com.study.stockmanagementstudycase.builder.BaseBuilder;
+import com.study.stockmanagementstudycase.builder.dto.CustomPagingBuilder;
+import com.study.stockmanagementstudycase.common.model.dto.CustomPaging;
+import com.study.stockmanagementstudycase.model.dto.request.wareHouse.WareHousePagingRequest;
+
+public class WareHousePagingRequestBuilder extends BaseBuilder<WareHousePagingRequest> {
+    public WareHousePagingRequestBuilder() {
+        super(WareHousePagingRequest.class);
+    }
+
+    public WareHousePagingRequestBuilder withValidFields() {
+        return this
+                .withPagination(new CustomPagingBuilder().withValidFields().build());
+    }
+
+    public WareHousePagingRequestBuilder withPagination(
+            final CustomPaging customPaging
+    ) {
+        data.setPagination(customPaging);
+        return this;
+    }
+
+    @Override
+    public WareHousePagingRequest build() {
+        return super.build();
+    }
+}

--- a/src/test/java/com/study/stockmanagementstudycase/builder/dto/wareHouse/WareHouseUpdateRequestBuilder.java
+++ b/src/test/java/com/study/stockmanagementstudycase/builder/dto/wareHouse/WareHouseUpdateRequestBuilder.java
@@ -1,4 +1,4 @@
-package com.study.stockmanagementstudycase.builder.dto;
+package com.study.stockmanagementstudycase.builder.dto.wareHouse;
 
 import com.github.javafaker.Faker;
 import com.study.stockmanagementstudycase.builder.BaseBuilder;

--- a/src/test/java/com/study/stockmanagementstudycase/service/stock/impl/StockCreateServiceImplTests.java
+++ b/src/test/java/com/study/stockmanagementstudycase/service/stock/impl/StockCreateServiceImplTests.java
@@ -1,7 +1,7 @@
 package com.study.stockmanagementstudycase.service.stock.impl;
 
 import com.study.stockmanagementstudycase.base.BaseServiceTest;
-import com.study.stockmanagementstudycase.builder.dto.StockCreateRequestBuilder;
+import com.study.stockmanagementstudycase.builder.dto.stock.StockCreateRequestBuilder;
 import com.study.stockmanagementstudycase.model.Stock;
 import com.study.stockmanagementstudycase.model.dto.request.stock.StockCreateRequest;
 import com.study.stockmanagementstudycase.model.entities.StockEntity;

--- a/src/test/java/com/study/stockmanagementstudycase/service/stock/impl/StockUpdateServiceImplTest.java
+++ b/src/test/java/com/study/stockmanagementstudycase/service/stock/impl/StockUpdateServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.study.stockmanagementstudycase.service.stock.impl;
 
 import com.study.stockmanagementstudycase.base.BaseServiceTest;
-import com.study.stockmanagementstudycase.builder.dto.StockUpdateRequestBuilder;
+import com.study.stockmanagementstudycase.builder.dto.stock.StockUpdateRequestBuilder;
 import com.study.stockmanagementstudycase.common.exception.StockNotFoundException;
 import com.study.stockmanagementstudycase.model.Stock;
 import com.study.stockmanagementstudycase.model.dto.request.stock.StockUpdateRequest;

--- a/src/test/java/com/study/stockmanagementstudycase/service/stockTransaction/impl/StockTransactionCreateServiceImplTest.java
+++ b/src/test/java/com/study/stockmanagementstudycase/service/stockTransaction/impl/StockTransactionCreateServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.study.stockmanagementstudycase.service.stockTransaction.impl;
 
 import com.study.stockmanagementstudycase.base.BaseServiceTest;
-import com.study.stockmanagementstudycase.builder.dto.StockCreateRequestBuilder;
+import com.study.stockmanagementstudycase.builder.dto.stock.StockCreateRequestBuilder;
 import com.study.stockmanagementstudycase.model.Stock;
 import com.study.stockmanagementstudycase.model.StockTransaction;
 import com.study.stockmanagementstudycase.model.WareHouse;

--- a/src/test/java/com/study/stockmanagementstudycase/service/warehouse/impl/WareHouseCreateServiceImplTest.java
+++ b/src/test/java/com/study/stockmanagementstudycase/service/warehouse/impl/WareHouseCreateServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.study.stockmanagementstudycase.service.warehouse.impl;
 
 import com.study.stockmanagementstudycase.base.BaseServiceTest;
-import com.study.stockmanagementstudycase.builder.dto.WareHouseCreateRequestBuilder;
+import com.study.stockmanagementstudycase.builder.dto.wareHouse.WareHouseCreateRequestBuilder;
 import com.study.stockmanagementstudycase.common.exception.WareHouseAlreadyExistException;
 import com.study.stockmanagementstudycase.model.WareHouse;
 import com.study.stockmanagementstudycase.model.dto.request.wareHouse.WareHouseCreateRequest;

--- a/src/test/java/com/study/stockmanagementstudycase/service/warehouse/impl/WareHouseServiceImplTest.java
+++ b/src/test/java/com/study/stockmanagementstudycase/service/warehouse/impl/WareHouseServiceImplTest.java
@@ -1,9 +1,11 @@
 package com.study.stockmanagementstudycase.service.warehouse.impl;
 
-import com.github.javafaker.Faker;
 import com.study.stockmanagementstudycase.base.BaseServiceTest;
+import com.study.stockmanagementstudycase.builder.dto.wareHouse.WareHousePagingRequestBuilder;
 import com.study.stockmanagementstudycase.common.exception.WareHouseNotFoundException;
+import com.study.stockmanagementstudycase.common.model.dto.CustomPage;
 import com.study.stockmanagementstudycase.model.WareHouse;
+import com.study.stockmanagementstudycase.model.dto.request.wareHouse.WareHousePagingRequest;
 import com.study.stockmanagementstudycase.model.entities.WareHouseEntity;
 import com.study.stockmanagementstudycase.repository.WareHouseRepository;
 import com.study.stockmanagementstudycase.service.wareHouse.impl.WareHouseServiceImpl;
@@ -12,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,10 +31,9 @@ public class WareHouseServiceImplTest extends BaseServiceTest {
     @Test
     void givenWareHouseEntities_whenGetWareHouses_thenReturnWareHouseDomainModels() {
         // Given
-
-        final int pageNumber = Faker.instance().number().randomDigitNotZero();
-        final int pageSize = Faker.instance().number().randomDigitNotZero();
-
+        final WareHousePagingRequest mockWareHousePagingRequest = new WareHousePagingRequestBuilder()
+                .withValidFields()
+                .build();
 
         final List<WareHouseEntity> mockWareHouseEntities = List.of(
                 WareHouseEntity.builder().id(UUID.randomUUID().toString()).build(),
@@ -38,46 +41,62 @@ public class WareHouseServiceImplTest extends BaseServiceTest {
                 WareHouseEntity.builder().id(UUID.randomUUID().toString()).build()
         );
 
-        // When
-        Mockito.when(wareHouseRepository.findAll())
-                .thenReturn(mockWareHouseEntities);
-
-        // Then
-        // TODO Bu kısım değiştirildi, düzeltilmesi gerekiyor.
-        final List<WareHouse> response = null;//wareHouseService.getWareHouses(pageNumber);
-
-        Assertions.assertNotNull(response);
-
-        Assertions.assertEquals(response.size(), 3);
-
-
-        // Verify
-        Mockito.verify(
-                wareHouseRepository,
-                Mockito.times(1)
-        ).findAll();
-    }
-
-    @Test
-    void givenEmptyWareHouseEntities_whenGetWareHouses_thenThrowsException() {
-        // Given
-        final List<WareHouseEntity> mockWareHouseEntities = List.of();
+        final Page<WareHouseEntity> mockWareHouseEntityPage = new PageImpl<>(
+                mockWareHouseEntities,
+                mockWareHousePagingRequest.toPageable(),
+                mockWareHouseEntities.size()
+        );
 
         // When
-        Mockito.when(wareHouseRepository.findAll())
-                .thenReturn(mockWareHouseEntities);
+        Mockito.when(wareHouseRepository.findAll(mockWareHousePagingRequest.toPageable()))
+                .thenReturn(mockWareHouseEntityPage);
 
         // Then
-        Assertions.assertThrowsExactly(
-                WareHouseNotFoundException.class,
-                () -> wareHouseService.getWareHouses(Mockito.any())
+        final CustomPage<WareHouse> response = wareHouseService
+                .getWareHouses(mockWareHousePagingRequest);
+
+        Assertions.assertEquals(
+                mockWareHouseEntities.size(),
+                response.getTotalElementCount()
         );
 
         // Verify
         Mockito.verify(
                 wareHouseRepository,
                 Mockito.times(1)
-        ).findAll();
+        ).findAll(mockWareHousePagingRequest.toPageable());
+    }
+
+    @Test
+    void givenEmptyWareHouseEntities_whenGetWareHouses_thenThrowsException() {
+        // Given
+        final WareHousePagingRequest mockWareHousePagingRequest = new WareHousePagingRequestBuilder()
+                .withValidFields()
+                .build();
+
+        final List<WareHouseEntity> mockWareHouseEntities = List.of();
+
+        final Page<WareHouseEntity> mockWareHouseEntityPage = new PageImpl<>(
+                mockWareHouseEntities,
+                mockWareHousePagingRequest.toPageable(),
+                mockWareHouseEntities.size()
+        );
+
+        // When
+        Mockito.when(wareHouseRepository.findAll(mockWareHousePagingRequest.toPageable()))
+                .thenReturn(mockWareHouseEntityPage);
+
+        // Then
+        Assertions.assertThrowsExactly(
+                WareHouseNotFoundException.class,
+                () -> wareHouseService.getWareHouses(mockWareHousePagingRequest)
+        );
+
+        // Verify
+        Mockito.verify(
+                wareHouseRepository,
+                Mockito.times(1)
+        ).findAll(mockWareHousePagingRequest.toPageable());
 
     }
 
@@ -123,6 +142,76 @@ public class WareHouseServiceImplTest extends BaseServiceTest {
                 wareHouseRepository,
                 Mockito.times(1)
         ).findById(Mockito.anyString());
+
+    }
+
+    @Test
+    void givenWareHouseEntitiesWithStatusIsFalse_whenGetDeletedWareHouses_thenReturnCustomPage() {
+        // Given
+        final WareHousePagingRequest mockWareHousePagingRequest = new WareHousePagingRequestBuilder()
+                .withValidFields()
+                .build();
+
+        final List<WareHouseEntity> mockWareHouseEntitiesWithStatusIsFalse = List.of(
+                WareHouseEntity.builder().id(UUID.randomUUID().toString()).status(false).build(),
+                WareHouseEntity.builder().id(UUID.randomUUID().toString()).status(false).build()
+        );
+
+        final Page<WareHouseEntity> mockWareHouseEntityPage = new PageImpl<>(
+                mockWareHouseEntitiesWithStatusIsFalse,
+                mockWareHousePagingRequest.toPageable(),
+                mockWareHouseEntitiesWithStatusIsFalse.size()
+        );
+
+        // When
+        Mockito.when(wareHouseRepository
+                        .findWareHouseEntitiesByStatusIsFalse(mockWareHousePagingRequest.toPageable()))
+                .thenReturn(mockWareHouseEntityPage);
+
+        // Then
+        final CustomPage<WareHouse> response = wareHouseService
+                .getDeletedWareHouses(mockWareHousePagingRequest);
+
+        Assertions.assertEquals(
+                mockWareHouseEntitiesWithStatusIsFalse.size(),
+                response.getTotalElementCount()
+        );
+
+        // Verify
+        Mockito.verify(wareHouseRepository, Mockito.times(1))
+                .findWareHouseEntitiesByStatusIsFalse(mockWareHousePagingRequest.toPageable());
+
+    }
+
+    @Test
+    void givenEmptyWareHouseEntities_whenGetDeletedWareHouses_thenThrowsWareHouseNotFoundException() {
+        // Given
+        final WareHousePagingRequest mockWareHousePagingRequest = new WareHousePagingRequestBuilder()
+                .withValidFields()
+                .build();
+
+        final List<WareHouseEntity> mockWareHouseEntitiesWithStatusIsFalse = List.of();
+
+        final Page<WareHouseEntity> mockWareHouseEntityPage = new PageImpl<>(
+                mockWareHouseEntitiesWithStatusIsFalse,
+                mockWareHousePagingRequest.toPageable(),
+                mockWareHouseEntitiesWithStatusIsFalse.size()
+        );
+
+        // When
+        Mockito.when(wareHouseRepository
+                        .findWareHouseEntitiesByStatusIsFalse(mockWareHousePagingRequest.toPageable()))
+                .thenReturn(mockWareHouseEntityPage);
+
+        // Then
+        Assertions.assertThrowsExactly(
+                WareHouseNotFoundException.class,
+                () -> wareHouseService.getDeletedWareHouses(mockWareHousePagingRequest)
+        );
+
+        // Verify
+        Mockito.verify(wareHouseRepository, Mockito.times(1))
+                .findWareHouseEntitiesByStatusIsFalse(mockWareHousePagingRequest.toPageable());
 
     }
 

--- a/src/test/java/com/study/stockmanagementstudycase/service/warehouse/impl/WareHouseUpdateServiceImplTest.java
+++ b/src/test/java/com/study/stockmanagementstudycase/service/warehouse/impl/WareHouseUpdateServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.study.stockmanagementstudycase.service.warehouse.impl;
 
 import com.study.stockmanagementstudycase.base.BaseServiceTest;
-import com.study.stockmanagementstudycase.builder.dto.WareHouseUpdateRequestBuilder;
+import com.study.stockmanagementstudycase.builder.dto.wareHouse.WareHouseUpdateRequestBuilder;
 import com.study.stockmanagementstudycase.common.exception.WareHouseAlreadyExistException;
 import com.study.stockmanagementstudycase.common.exception.WareHouseNotFoundException;
 import com.study.stockmanagementstudycase.model.WareHouse;


### PR DESCRIPTION
- Status'u false olan yani silinmiş olan WareHouse kayıtlarını dönen bir endpoint yazıldı. (localhost:8080/api/v1/warehouses/deleted)
- WareHouseService içerisinde bu endpoint için pagination yapısında bir metod yazıldı.
- İlgili servis metodunun unit testleri yazıldı.
- Diğer geliştirmelerde gözden kaçan, hatalı testler düzeltildi.
- CustomPaging, WareHousePagingRequest nesneleri için testlerde kullanılmak üzere özel builder sınıflar yazıldı.
- DML'de bir tane WareHouse kaydının status'u 0 değerine yani false'a çekildi. Bu sayede proje ayağa kaldırıldığı anda postman üzerinden bu geliştirme test edilebilir hale getirildi.